### PR TITLE
Potential fix for code scanning alert no. 17: Use of externally-controlled format string

### DIFF
--- a/server/static/voice.js
+++ b/server/static/voice.js
@@ -906,7 +906,7 @@ class VoiceChat {
             }));
             console.log(`Answer sent to ${fromUsername}`);
         } catch (error) {
-            console.error(`Error handling offer from ${fromUsername}:`, error);
+            console.error('Error handling offer from %s:', fromUsername, error);
             alert(`Failed to process call from ${fromUsername}: ${error.message}`);
         }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/SluberskiHomeLab/decentra/security/code-scanning/17](https://github.com/SluberskiHomeLab/decentra/security/code-scanning/17)

General fix approach: Avoid embedding untrusted data into the format string argument of `console.error` (or any util.format-like function). Instead, use a constant format string and pass untrusted data as subsequent arguments, or build a fully concatenated string and pass it as a single argument.

Best fix here: On line 909 in `server/static/voice.js`, change the logging call from a template literal that includes `fromUsername` in the first argument to a call that uses a fixed format string and passes `fromUsername` as an argument. This preserves the message content while ensuring the format string itself is constant. A simple pattern is: `console.error('Error handling offer from %s:', fromUsername, error);`, which mirrors the usage already present in `handleAnswer` on line 924 and keeps behavior consistent.

Concretely:
- In `server/static/voice.js`, locate the `catch (error) { ... }` block inside `async handleOffer(...)`.
- Replace `console.error(\`Error handling offer from ${fromUsername}:\`, error);` with `console.error('Error handling offer from %s:', fromUsername, error);`.
- No new imports or additional helper methods are needed; we only adjust the arguments to `console.error`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
