### PR TITLE
Potential fix for code scanning alert no. 6: Client-side URL redirect

### DIFF
--- a/server/static/chat.js
+++ b/server/static/chat.js
@@ -261,12 +261,41 @@
         };
     }
     
+    // Helper function to validate avatar image URLs
+    function isSafeAvatarUrl(url) {
+        if (typeof url !== 'string' || url.trim() === '') {
+            return false;
+        }
+        try {
+            // Resolve relative URLs against current origin
+            const parsed = new URL(url, window.location.origin);
+            const scheme = parsed.protocol.toLowerCase();
+            // Disallow dangerous schemes
+            if (scheme === 'javascript:' || scheme === 'vbscript:') {
+                return false;
+            }
+            // Optionally restrict to same-origin; adjust if external avatars are needed
+            if (parsed.origin !== window.location.origin) {
+                return false;
+            }
+            return true;
+        } catch (e) {
+            // If URL parsing fails, treat as unsafe
+            return false;
+        }
+    }
+
     // Helper function to create avatar element
     function createAvatarElement(avatarData, className = 'user-avatar') {
         const avatarEl = document.createElement('span');
         avatarEl.className = className;
         
-        if (avatarData && avatarData.avatar_type === 'image' && avatarData.avatar_data) {
+        if (
+            avatarData &&
+            avatarData.avatar_type === 'image' &&
+            avatarData.avatar_data &&
+            isSafeAvatarUrl(avatarData.avatar_data)
+        ) {
             // Image avatar
             const img = document.createElement('img');
             img.src = avatarData.avatar_data;


### PR DESCRIPTION
Potential fix for [https://github.com/SluberskiHomeLab/decentra/security/code-scanning/6](https://github.com/SluberskiHomeLab/decentra/security/code-scanning/6)

In general, to fix issues where untrusted data is used in URL contexts, you validate and constrain the value before assigning it to URL-bearing sinks (like `window.location`, `img.src`, `a.href`) so that only safe schemes, hosts, or paths are allowed. Ideally, URLs are either server-generated from a whitelist or client-side code enforces a strict allowlist of schemes/domains.

Here, the single best fix without changing existing functionality is to validate `avatarData.avatar_data` in `createAvatarElement` before assigning it to `img.src`. We can implement a small helper function (inside the same file) that checks the avatar URL and only allows:
- relative URLs (no scheme), which keep loading within the same origin, and/or
- data URLs (`data:image/...`) if those are needed.

If the value fails validation, we should avoid using it and fall back to the emoji avatar branch so the UI still works without breaking anything else.

Concretely:
- In `server/static/chat.js`, add a helper function above `createAvatarElement` such as `isSafeAvatarUrl(url)` that:
  - Returns `false` for empty or non-string values.
  - Attempts to parse absolute URLs with `new URL(url, window.location.origin)`.
  - Rejects dangerous schemes like `javascript:` and `vbscript:`.
  - Optionally restricts to same-origin (i.e., `parsed.origin === window.location.origin`) or to relative URLs.
- Update the `if` condition at lines 269–272 so that the image avatar branch only runs when `isSafeAvatarUrl(avatarData.avatar_data)` is true; otherwise, fall back to the emoji avatar branch.

No external library is needed; `URL` is standard.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
