### PR TITLE
Potential fix for code scanning alert no. 5: Clear text storage of sensitive information

### DIFF
--- a/server/static/auth.js
+++ b/server/static/auth.js
@@ -124,7 +124,6 @@
             
             // Store credentials for WebSocket authentication
             sessionStorage.setItem('username', username);
-            sessionStorage.setItem('password', password);
             sessionStorage.setItem('email', email);
             sessionStorage.setItem('authMode', 'signup');
             sessionStorage.setItem('inviteCode', inviteCode);
@@ -140,7 +139,6 @@
             
             // Store credentials for WebSocket authentication
             sessionStorage.setItem('username', username);
-            sessionStorage.setItem('password', password);
             sessionStorage.setItem('authMode', 'login');
             sessionStorage.setItem('inviteCode', inviteCode);
             


### PR DESCRIPTION
Potential fix for [https://github.com/SluberskiHomeLab/decentra/security/code-scanning/5](https://github.com/SluberskiHomeLab/decentra/security/code-scanning/5)

In general, the right fix is to avoid storing the clear-text password in client-side storage at all. Instead, pass only non-sensitive identifiers (e.g., username, auth mode, invite code, verification code) through `sessionStorage`, and let the server handle authentication directly when the user submits the form, or use a short-lived token or session identifier returned from the server. Since we must not change overall functionality more than necessary and cannot modify other files, the safest local change is to stop writing the `password` field into `sessionStorage` while keeping the rest of the flow (including redirects and other stored fields) unchanged.

Concretely, in `server/static/auth.js`:

- In the signup branch (lines ~118–131), remove the line that stores `password` into `sessionStorage`.
- In the login branch (lines ~135–145), remove the line that stores `password` into `sessionStorage`.
- Leave `username`, `email`, `authMode`, `inviteCode`, and `verificationCode` handling unchanged so that existing page flows still work as they do today, except that `/static/chat.html` will no longer be able to read a clear-text password from `sessionStorage`. If `/static/chat.html` currently depends on `sessionStorage.getItem('password')`, that page should be updated separately to use a more secure mechanism (e.g., server-side session), but that is out of scope for this snippet.

No new imports or helper methods are needed; the fix is purely the removal of insecure `sessionStorage.setItem('password', ...)` calls.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
